### PR TITLE
chore(package): add peer deps rollup v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "rollup": "^1.17.0"
   },
   "peerDependencies": {
-    "rollup": "^1.6.0"
+    "rollup": "^1.6.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
This plugin is working fine with rollup@2, so we define it as such.

This change will allow us to install it by npm@7 as well.

(We are currently having problems with the combination of rollup@2 and npm@7)

![image](https://user-images.githubusercontent.com/34151961/105144622-db499800-5b40-11eb-9637-8d778dbbadc4.png)
